### PR TITLE
Fix the handling of optional charm configuration in the opencti_connector charm library

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -91,3 +91,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           built-charm-path: ${{ steps.charmcraft.outputs.charms }}
           tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
+  publish-charm-libs:
+    name: Release charm libs
+    runs-on: ubuntu-24.04
+    needs: [ publish-charm ]
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: canonical/charming-actions/release-libraries@2.7.0
+        name: Release libs
+        with:
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/connectors/abuseipdb_ipblacklist/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/abuseipdb_ipblacklist/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/alienvault/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/alienvault/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/cisa_kev/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/cisa_kev/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/crowdstrike/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/crowdstrike/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/cyber_campaign/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/cyber_campaign/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/export_file_csv/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/export_file_csv/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/export_file_stix/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/export_file_stix/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/export_file_txt/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/export_file_txt/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/import_document/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/import_document/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/import_file_stix/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/import_file_stix/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/malwarebazaar/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/malwarebazaar/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/misp_feed/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/misp_feed/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/mitre/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/mitre/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/sekoia/charmcraft.yaml
+++ b/connectors/sekoia/charmcraft.yaml
@@ -30,7 +30,7 @@ config:
       type: string
       optional: false
     sekoia-create-observables:
-      description: create observables from indicators
+      description: (optional) create observables from indicators
       type: boolean
       optional: false
     connector-log-level:

--- a/connectors/sekoia/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/sekoia/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/urlscan/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/urlscan/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/urlscan_enrichment/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/urlscan_enrichment/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/virustotal_livehunt/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/virustotal_livehunt/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/connectors/vxvault/lib/charms/opencti/v0/opencti_connector.py
+++ b/connectors/vxvault/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/lib/charms/opencti/v0/opencti_connector.py
+++ b/lib/charms/opencti/v0/opencti_connector.py
@@ -11,7 +11,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 import abc
 import os
@@ -102,7 +102,7 @@ class OpenctiConnectorCharm(ops.CharmBase, abc.ABC):
         missing = []
         for config, config_meta in self._config_metadata().items():
             value = self.config.get(config)
-            if value is None and not config_meta["description"].strip().startswith("(optional)"):
+            if value is None and config_meta.get("optional") is False:
                 missing.append(config)
         if missing:
             raise NotReady("missing configurations: {}".format(", ".join(missing)))

--- a/scripts/gen_connector_charm.py
+++ b/scripts/gen_connector_charm.py
@@ -758,7 +758,7 @@ def gen_sekoia_connector(location: pathlib.Path, version: str) -> None:
                 "optional": True,
             },
             "sekoia-create-observables": {
-                "description": "create observables from indicators",
+                "description": "(optional) create observables from indicators",
                 "type": "boolean",
                 "optional": False,
             },


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fix the handling of optional charm configuration in the opencti_connector charm library.
Also add a Github action to automatically publish charm libraries.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
