### PR TITLE
Install ca-certificates in the connector containers

### DIFF
--- a/connector-template/rock/rockcraft.yaml.j2
+++ b/connector-template/rock/rockcraft.yaml.j2
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/abuseipdb_ipblacklist/rock/rockcraft.yaml
+++ b/connectors/abuseipdb_ipblacklist/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/alienvault/rock/rockcraft.yaml
+++ b/connectors/alienvault/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/cisa_kev/rock/rockcraft.yaml
+++ b/connectors/cisa_kev/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/crowdstrike/rock/rockcraft.yaml
+++ b/connectors/crowdstrike/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/cyber_campaign/rock/rockcraft.yaml
+++ b/connectors/cyber_campaign/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/export_file_csv/rock/rockcraft.yaml
+++ b/connectors/export_file_csv/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/export_file_stix/rock/rockcraft.yaml
+++ b/connectors/export_file_stix/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/export_file_txt/rock/rockcraft.yaml
+++ b/connectors/export_file_txt/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/import_document/rock/rockcraft.yaml
+++ b/connectors/import_document/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/import_file_stix/rock/rockcraft.yaml
+++ b/connectors/import_file_stix/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/ipinfo/rock/rockcraft.yaml
+++ b/connectors/ipinfo/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/malwarebazaar/rock/rockcraft.yaml
+++ b/connectors/malwarebazaar/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/misp_feed/rock/rockcraft.yaml
+++ b/connectors/misp_feed/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/mitre/rock/rockcraft.yaml
+++ b/connectors/mitre/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/sekoia/rock/rockcraft.yaml
+++ b/connectors/sekoia/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/urlhaus/rock/rockcraft.yaml
+++ b/connectors/urlhaus/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/urlscan/rock/rockcraft.yaml
+++ b/connectors/urlscan/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/urlscan_enrichment/rock/rockcraft.yaml
+++ b/connectors/urlscan_enrichment/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/virustotal_livehunt/rock/rockcraft.yaml
+++ b/connectors/virustotal_livehunt/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/connectors/vxvault/rock/rockcraft.yaml
+++ b/connectors/vxvault/rock/rockcraft.yaml
@@ -39,3 +39,9 @@ parts:
         --target $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages \
         -r $(find -name requirements.txt)
       cp entrypoint.sh $CRAFT_PART_INSTALL/
+  ca-certificates:
+    source: .
+    plugin: nil
+    stage-packages:
+      - openssl_data
+      - ca-certificates_data

--- a/src/charm.py
+++ b/src/charm.py
@@ -427,7 +427,12 @@ class OpenCTICharm(ops.CharmBase):
         if not self.unit.is_leader():
             return
         if _PEER_SECRET_FIELD in peer_integration.data[self.app]:
-            return
+            # bypass a strange Juju issue where secrets go missing without reason during an upgrade
+            try:
+                self.model.get_secret(id=peer_integration.data[self.app][_PEER_SECRET_FIELD])
+                return
+            except ops.SecretNotFoundError:
+                pass
         secret = self.app.add_secret(
             {
                 _PEER_SECRET_ADMIN_TOKEN_SECRET_FIELD: str(

--- a/src/charm.py
+++ b/src/charm.py
@@ -428,11 +428,12 @@ class OpenCTICharm(ops.CharmBase):
             return
         if _PEER_SECRET_FIELD in peer_integration.data[self.app]:
             # bypass a strange Juju issue where secrets go missing without reason during an upgrade
+            secret_id = peer_integration.data[self.app][_PEER_SECRET_FIELD]
             try:
-                self.model.get_secret(id=peer_integration.data[self.app][_PEER_SECRET_FIELD])
+                self.model.get_secret(id=secret_id)
                 return
             except ops.SecretNotFoundError:
-                pass
+                logger.error("secret %s removed unexpectedly", secret_id)
         secret = self.app.add_secret(
             {
                 _PEER_SECRET_ADMIN_TOKEN_SECRET_FIELD: str(

--- a/src/opencti.py
+++ b/src/opencti.py
@@ -3,6 +3,7 @@
 
 """OpenCTI API client."""
 import functools
+import logging
 import pathlib
 import secrets
 import typing
@@ -12,6 +13,8 @@ import gql
 import gql.dsl
 import gql.transport.requests
 import graphql
+
+gql.transport.requests.log.setLevel(logging.WARNING)
 
 
 class OpenctiUser(typing.NamedTuple):


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Install ca-certificates to the connector containers and bypass a strange problem encountered during deployment.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
