### PR TITLE
Add a changelog

### DIFF
--- a/.github/pull_request_template.yaml
+++ b/.github/pull_request_template.yaml
@@ -28,5 +28,6 @@ Applicable spec: <link>
 - [ ] The documentation is generated using `src-docs`
 - [ ] The documentation for charmhub is updated
 - [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
+- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
 
 <!-- Explanation for any unchecked items above -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+docs/changelog.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Each revision is versioned by the date of the revision.
+
 ## 2025-03-04
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2025-03-04
+
+### Added
+
+- Changelog added for tracking changes.


### PR DESCRIPTION
Applicable spec: ISD-089

### Overview

<!-- A high level overview of the change -->

Add a changelog at docs/changelog.md. This allows the changelog to be displayed on charmhub.

A soft link to the changelog is created at the root called CHANGELOG.md as this is a common location to store changelog.

### Rationale

<!-- The reason the change is needed -->

This allows the users to able track changes on the charm on charmhub.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
