### PR TITLE
Add documents for backup, redeployment and observability

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,3 +9,6 @@ CVE-2024-34156
 CVE-2024-45338
 # axios (package.json)
 CVE-2025-27152
+# xml-crypto (package.json)
+CVE-2025-29774
+CVE-2025-29775

--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,5 @@ CVE-2023-45288
 CVE-2024-34156
 # pebble
 CVE-2024-45338
+# axios (package.json)
+CVE-2025-27152

--- a/docs/how-to/backup.md
+++ b/docs/how-to/backup.md
@@ -2,5 +2,10 @@
 
 OpenCTI charms store data inside the OpenSearch instance and S3-compatible 
 storage. Refer to the documentation of the respective charms for instructions 
-on backing up data in [OpenSearch](https://charmhub.io/opensearch/docs/h-configure-s3)
+on backing up data in [OpenSearch](https://charmhub.io/opensearch/docs/h-create-backup)
 and S3-compatible storage.
+
+## Restore OpenCTI charm from a backup
+
+Follow the [guide in the OpenSearch charm](https://charmhub.io/opensearch/docs/h-restore-backup)
+for how to restore data in the OpenCTI charm.

--- a/docs/how-to/observability.md
+++ b/docs/how-to/observability.md
@@ -1,4 +1,4 @@
-# How to Integrate with COS
+# How to integrate with COS
 
 The OpenCTI charm exposes standard [COS](https://charmhub.io/topics/canonical-observability-stack)
 integration endpoints. These include the `metrics-endpoint` [endpoint](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/application/#application-endpoint), 
@@ -6,8 +6,8 @@ which can be integrated with the [`prometheus-k8s` charm](https://charmhub.io/pr
 for Prometheus metrics and alert rules; the `grafana-dashboard` endpoint, which
 can be integrated with the [`grafana-k8s` charm](https://charmhub.io/grafana-k8s)
 to provide the OpenCTI Grafana dashboard; and the `logging` endpoint, which can
-be integrated with the [`loki-k8s` charm](https://charmhub.io/loki-k8s) for 
-exporting logs from both the OpenCTI platform and OpenCTI workers.
+be integrated with the [`loki-k8s` charm](https://charmhub.io/loki-k8s) to 
+export logs from both the OpenCTI platform and OpenCTI workers.
 
 All OpenCTI connector charms support the `logging` endpoint for exporting logs 
 from OpenCTI connectors.

--- a/docs/how-to/observability.md
+++ b/docs/how-to/observability.md
@@ -1,0 +1,13 @@
+# How to Integrate with COS
+
+The OpenCTI charm exposes standard [COS](https://charmhub.io/topics/canonical-observability-stack)
+integration endpoints. These include the `metrics-endpoint` [endpoint](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/application/#application-endpoint), 
+which can be integrated with the [`prometheus-k8s` charm](https://charmhub.io/prometheus-k8s)
+for Prometheus metrics and alert rules; the `grafana-dashboard` endpoint, which
+can be integrated with the [`grafana-k8s` charm](https://charmhub.io/grafana-k8s)
+to provide the OpenCTI Grafana dashboard; and the `logging` endpoint, which can
+be integrated with the [`loki-k8s` charm](https://charmhub.io/loki-k8s) for 
+exporting logs from both the OpenCTI platform and OpenCTI workers.
+
+All OpenCTI connector charms support the `logging` endpoint for exporting logs 
+from OpenCTI connectors.

--- a/docs/how-to/observability.md
+++ b/docs/how-to/observability.md
@@ -1,13 +1,16 @@
 # How to integrate with COS
 
 The OpenCTI charm exposes standard [COS](https://charmhub.io/topics/canonical-observability-stack)
-integration endpoints. These include the `metrics-endpoint` [endpoint](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/application/#application-endpoint), 
-which can be integrated with the [`prometheus-k8s` charm](https://charmhub.io/prometheus-k8s)
-for Prometheus metrics and alert rules; the `grafana-dashboard` endpoint, which
-can be integrated with the [`grafana-k8s` charm](https://charmhub.io/grafana-k8s)
-to provide the OpenCTI Grafana dashboard; and the `logging` endpoint, which can
-be integrated with the [`loki-k8s` charm](https://charmhub.io/loki-k8s) to 
-export logs from both the OpenCTI platform and OpenCTI workers.
+integration [endpoints](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/application/#application-endpoint). 
+
+These include:
+
+- `metrics-endpoint`: integrate with the [`prometheus-k8s` charm](https://charmhub.io/prometheus-k8s)
+  for Prometheus metrics and alert rules.
+- `grafana-dashboard`: integrate with the [`grafana-k8s` charm](https://charmhub.io/grafana-k8s)
+  to provide the OpenCTI Grafana dashboard.
+- `logging`: integrate with the [`loki-k8s` charm](https://charmhub.io/loki-k8s)
+  to export logs from both the OpenCTI platform and OpenCTI workers.
 
 All OpenCTI connector charms support the `logging` endpoint for exporting logs 
 from OpenCTI connectors.

--- a/docs/how-to/redeploy.md
+++ b/docs/how-to/redeploy.md
@@ -1,10 +1,10 @@
-# How to Redeploy the OpenCTI Charm
+# How to redeploy the OpenCTI charm
 
 Both the OpenCTI charm and the OpenCTI connector are stateless charms, so you 
-can redeploy the OpenCTI charm at any time.
+can redeploy the OpenCTI charm at any time using `juju refresh`.
 
 However, one thing to keep in mind is that the newly deployed charm must use the
 same Juju application name as the previous OpenCTI charm. This is because the
 OpenCTI charm uses the Juju application name as the OpenSearch index prefix. 
-Doing so ensures that the new OpenCTI charm inherits the old data created by
+Using the same Juju application name ensures that the new OpenCTI charm inherits the old data created by
 the previous charm.

--- a/docs/how-to/redeploy.md
+++ b/docs/how-to/redeploy.md
@@ -1,0 +1,10 @@
+# How to Redeploy the OpenCTI Charm
+
+Both the OpenCTI charm and the OpenCTI connector are stateless charms, so you 
+can redeploy the OpenCTI charm at any time.
+
+However, one thing to keep in mind is that the newly deployed charm must use the
+same Juju application name as the previous OpenCTI charm. This is because the
+OpenCTI charm uses the Juju application name as the OpenSearch index prefix. 
+Doing so ensures that the new OpenCTI charm inherits the old data created by
+the previous charm.

--- a/terraform/product/modules/rabbitmq-server/variables.tf
+++ b/terraform/product/modules/rabbitmq-server/variables.tf
@@ -4,7 +4,7 @@
 variable "app_name" {
   description = "Name of the application in the Juju model."
   type        = string
-  default     = "opencti"
+  default     = "rabbitmq-server"
 }
 
 variable "channel" {

--- a/terraform/product/modules/redis-k8s/variables.tf
+++ b/terraform/product/modules/redis-k8s/variables.tf
@@ -4,7 +4,7 @@
 variable "app_name" {
   description = "Name of the application in the Juju model."
   type        = string
-  default     = "opencti"
+  default     = "redis-k8s"
 }
 
 variable "channel" {

--- a/terraform/product/modules/s3-integrator/variables.tf
+++ b/terraform/product/modules/s3-integrator/variables.tf
@@ -4,7 +4,7 @@
 variable "app_name" {
   description = "Name of the application in the Juju model."
   type        = string
-  default     = "opencti"
+  default     = "s3-integrator"
 }
 
 variable "channel" {


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add documents for backup, redeployment and observability.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
