### PR TITLE
Skip the connector reconciliation process on non-leader units

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -686,6 +686,8 @@ class OpenCTICharm(ops.CharmBase):
 
     def _reconcile_connector(self) -> None:
         """Run charm reconcile function for OpenCTI connectors."""
+        if not self.unit.is_leader():
+            return
         client = opencti.OpenctiClient(
             url="http://localhost:8080",
             api_token=self._get_peer_secret(_PEER_SECRET_ADMIN_TOKEN_SECRET_FIELD),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -131,7 +131,7 @@ async def test_opencti_workers(get_unit_ips, ops_test):
         timeout=5,
     )
     worker_count = resp.json()["data"]["rabbitMQMetrics"]["consumers"]
-    assert worker_count == str(3)
+    assert worker_count == str(6)
 
 
 async def test_opencti_client(get_unit_ips, ops_test):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -70,6 +70,7 @@ async def test_deploy_charm(
         resources={
             "opencti-image": pytestconfig.getoption("--opencti-image"),
         },
+        num_units=2,
     )
     redis_k8s = await model.deploy("redis-k8s", channel="latest/edge")
     nginx_ingress_integrator = await model.deploy(


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Non-leader units can't modify the application databag in the integration. Therefore, skip the connector reconciliation process on non-leader units.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
