### PR TITLE
Force refresh the ingress elation data on every event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -198,6 +198,12 @@ class OpenCTICharm(ops.CharmBase):
             relation_name="ingress",
             port=8080,
         )
+        # Sometimes the ingress library doesn't properly handle pod
+        # restarts,which can cause the IP field inside the ingress
+        # relation data to become stale, resulting in ingress failures.
+        # As a workaround, force refresh the ingress relation data
+        # (especially the ip field) on every event.
+        ingress._publish_auto_data()
         self.framework.observe(ingress.on.ready, self._reconcile)
         self.framework.observe(ingress.on.revoked, self._reconcile)
         return ingress

--- a/src/charm.py
+++ b/src/charm.py
@@ -203,7 +203,7 @@ class OpenCTICharm(ops.CharmBase):
         # relation data to become stale, resulting in ingress failures.
         # As a workaround, force refresh the ingress relation data
         # (especially the ip field) on every event.
-        ingress._publish_auto_data()
+        ingress._publish_auto_data()  # pylint: disable=protected-access
         self.framework.observe(ingress.on.ready, self._reconcile)
         self.framework.observe(ingress.on.revoked, self._reconcile)
         return ingress


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Sometimes the ingress library doesn't properly handle pod restarts, which can cause the IP field inside the ingress relation data to become stale, resulting in ingress failures. As a workaround, force refresh the ingress relation data (especially the ip field) on every event.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
