### PR TITLE
[-+] typo on "Deploy the OpenCTI charm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In the Kubernetes model, deploy the OpenCTI charm along with the rest of
 dependencies.
 
 ```bash
-juju switch lxd:welcome-microk8s
+juju switch microk8s:welcome-microk8s
 
 juju deploy minio --channel ckf-1.9/stable --config access-key=minioadmin --config secret-key=minioadmin
 juju deploy s3-integrator --config "endpoint=http://minio-endpoints.welcome-microk8s.svc.cluster.local:9000" --config bucket=opencti


### PR DESCRIPTION
The controller used is incorrect, as it should be the microk8s one. Model is correct.

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
