### PR TITLE
Trivial - Configuration error test on OpenCTI

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -532,7 +532,8 @@ class OpenCTICharm(ops.CharmBase):
             env["ELASTICSEARCH__USERNAME"] = username
         if password:
             env["ELASTICSEARCH__PASSWORD"] = password
-        return env
+        env["ELASTICSEARCH__URL"] = "bad-url-this-will-crash"
+	return env
 
     def _extract_opensearch_info(self) -> dict:
         """Extract opensearch connection information from the opensearch integration.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A configuration change to the _gen_opensearch_env(self) function -->

### Rationale

<!-- The change is being introduced to test the configuration rollback capability of the charm-->

### Juju Events Changes

<!-- NA -->

### Module Changes

<!-- NA -->

### Library Changes

<!-- NA -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- This is a test change that will be rolled back -->
