### PR TITLE
NTI rock entrypoint fix

### DIFF
--- a/connectors/nti/rock/rockcraft.yaml
+++ b/connectors/nti/rock/rockcraft.yaml
@@ -32,7 +32,7 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/opt
       cd external-import/nti
       cp -rp src $CRAFT_PART_INSTALL/opt/NTI-connector
-      
+      echo 'cd /opt/NTI-connector; python3 main.py' > entrypoint.sh
       cat entrypoint.sh | grep NTI-connector
       mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.12/dist-packages
       pip install \

--- a/scripts/gen_connector_charm.py
+++ b/scripts/gen_connector_charm.py
@@ -871,6 +871,7 @@ def gen_nti_connector(location: pathlib, version: str) -> None:
             """
         ),
         install_location="NTI-connector",
+        generate_entrypoint="echo 'cd /opt/NTI-connector; python3 main.py' > entrypoint.sh",
     )
 
 @connector_generator("sekoia")


### PR DESCRIPTION
The entrypoint was kept from the original repo, which is incorrect in this case, should have been configured

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
