### PR TITLE
Add landing pages to OpenCTI documents

### DIFF
--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,25 @@
+# How-to guides
+
+Guides for managing the full operations lifecycle of the OpenCTI charms,
+from user operation and maintenance to developer contribution. Each 
+guide assumes that you've already deployed the charm with Juju.
+
+## Guide for charm users
+
+Day-to-day operational tasks, including account management and database
+backups. Initial setup and long-term maintenance, including 
+observability using the Canonical Observability Stack, charm upgrades,
+and redeployment.
+
+* [Account management](./account.md)
+* [Database backup](./backup.md)
+* [Observability integration](./observability.md)
+* [Redeployment](./redeploy.md)
+* [Charm upgrade](./upgrade.md)
+
+## Guide for developers
+
+Learn the guidelines and best practices before contributing to the
+backup charm project.
+
+* [Contribute](./contribute.md)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -20,6 +20,6 @@ and redeployment.
 ## Guide for developers
 
 Learn the guidelines and best practices before contributing to the
-backup charm project.
+OpenCTI charms project.
 
 * [Contribute](./contribute.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,24 @@
+# Reference
+
+Technical specifications and architectural details for OpenCTI charms
+serve as authoritative look-up material when configuring, extending,
+or integrating the charm.
+
+## Charm configuration and operations
+
+Operators control charm behavior through configuration options and Juju
+actions. Understanding the overall charm architecture provides the 
+structural context needed to see how those settings and actions interact
+at runtime.
+
+* [Actions](actions.md)
+* [Configurations](configurations.md)
+* [Integrations](integrations.md)
+* [Observability](observability.md)
+
+## Charm architecture and designs
+
+Components and dependencies within the Bacula charms, along with the
+architecture decisions made during charm creation.
+
+* [Charm architecture](charm-architecture.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -13,12 +13,13 @@ at runtime.
 
 * [Actions](actions.md)
 * [Configurations](configurations.md)
-* [Integrations](integrations.md)
 * [Observability](observability.md)
 
 ## Charm architecture and designs
 
-Components and dependencies within the OpenCTI charms, along with the
-architecture decisions made during charm creation.
+Components and dependencies within the OpenCTI charms,
+architecture decisions made during charm creation, and how
+the charms connect to the broader Juju ecosystem.
 
 * [Charm architecture](charm-architecture.md)
+* [Integrations](integrations.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,7 +18,7 @@ at runtime.
 
 ## Charm architecture and designs
 
-Components and dependencies within the Bacula charms, along with the
+Components and dependencies within the OpenCTI charms, along with the
 architecture decisions made during charm creation.
 
 * [Charm architecture](charm-architecture.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,9 +7,8 @@ or integrating the charm.
 ## Charm configuration and operations
 
 Operators control charm behavior through configuration options and Juju
-actions. Understanding the overall charm architecture provides the 
-structural context needed to see how those settings and actions interact
-at runtime.
+actions. Here are the configuration and day-to-day operation related to
+OpenCTI charms.
 
 * [Actions](actions.md)
 * [Configurations](configurations.md)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add landing pages to OpenCTI documents

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

Add landing pages to OpenCTI documents.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
