### PR TITLE
feat: Upgraded opencti version and pinned yarn version due to packing…

### DIFF
--- a/opencti_rock/rockcraft.yaml
+++ b/opencti_rock/rockcraft.yaml
@@ -40,7 +40,7 @@ parts:
       craftctl default
       yarn set version 4.13.0
       cd opencti-platform/opencti-graphql/
-      yarn install --immutable --immutable-cache
+      yarn install --immutable
       yarn build:prod
       yarn cache clean --all
       mkdir -p $CRAFT_PART_INSTALL/opt/opencti

--- a/opencti_rock/rockcraft.yaml
+++ b/opencti_rock/rockcraft.yaml
@@ -3,7 +3,7 @@
 
 name: opencti
 base: ubuntu@24.04
-version: &version '6.9.28'
+version: &version '6.9.29'
 summary: Open Cyber Threat Intelligence Platform
 description: >-
   OpenCTI is an open source platform allowing organizations to manage their 
@@ -38,9 +38,9 @@ parts:
       - libffi-dev
     override-build: |
       craftctl default
-      yarn policies set-version stable
+      yarn set version 4.13.0
       cd opencti-platform/opencti-graphql/
-      yarn install --frozen-lockfile
+      yarn install --immutable --immutable-cache
       yarn build:prod
       yarn cache clean --all
       mkdir -p $CRAFT_PART_INSTALL/opt/opencti

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -25,7 +25,7 @@ def _kebab_to_snake(string: str) -> str:
     return string.replace("-", "_")
 
 
-_CONNECTOR_TEST_PARAMS = []
+_CONNECTOR_TEST_PARAMS: list[object] = []
 
 
 def _add_connector_test_params(


### PR DESCRIPTION
… issues.

Applicable spec: <link>

### Overview

With the new Yarn versions the rock is failing to pack. Pinned the yarn and also upgraded the OpenCTI while I was there.
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
