### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -3,7 +3,7 @@ name: Publish to edge
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
 
 jobs:
@@ -13,13 +13,16 @@ jobs:
     outputs:
       charm-dirs: ${{ steps.charm-dirs.outputs.charm-dirs }}
     steps:
-      - uses: actions/checkout@v6.0.2
-      - id: charm-dirs
-        run: |
-          echo charm-dirs=`find -name charmcraft.yaml | xargs dirname | jq --raw-input --slurp 'split("\n") | map(select(. != ""))'` >> $GITHUB_OUTPUT
+    - uses: actions/checkout@v6.0.2
+    - id: charm-dirs
+      run: |
+        echo charm-dirs=`find -name charmcraft.yaml | xargs dirname | jq --raw-input --slurp 'split("\n") | map(select(. != ""))'` >> $GITHUB_OUTPUT
 
   publish-charm:
-    needs: [ find-charms ]
+    needs: [find-charms]
+    permissions:
+      actions: read
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -27,80 +30,80 @@ jobs:
     name: Publish Charm (${{ matrix.charm-dir }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - name: Remove Android SDK
-        run: sudo rm -rf /usr/local/lib/android
-      - name: change directory
-        run: |
-          TEMP_DIR=$(mktemp -d)
-          cp -rp ./${{ matrix.charm-dir }}/. $TEMP_DIR
-          rm -rf .* * || :
-          cp -rp $TEMP_DIR/. .
-          rm -rf $TEMP_DIR
-      - name: setup lxd
-        uses: canonical/setup-lxd@v1
-      - name: find rock
-        id: rock-dir
-        run: |
-          echo rock-dir=`dirname *rock/rockcraft.yaml` >> $GITHUB_OUTPUT
-      - name: build rock
-        id: rockcraft
-        run: |
-          sudo snap install --channel latest/stable --classic rockcraft
-          cd ${{ steps.rock-dir.outputs.rock-dir }}
-          rockcraft pack --verbosity trace
-          echo rock=`ls *.rock` >> $GITHUB_OUTPUT
-      - run: |
-          echo rockcraft pack:
-          echo ${{ steps.rockcraft.outputs.rock }}
-      - name: upload rock
-        run: |
-          cd ${{ steps.rock-dir.outputs.rock-dir }}
-          docker run -d -p 5000:5000 --name registry registry:latest
-          rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:${{ steps.rockcraft.outputs.rock }} docker://localhost:5000/rock:latest
-      - name: build charm
-        id: charmcraft
-        run: |
-          sudo snap install --channel latest/stable --classic charmcraft
-          charmcraft pack --verbosity trace
-          echo charms=`ls *.charm` >> $GITHUB_OUTPUT
-      - run: |
-          echo charmcraft pack:
-          echo ${{ steps.charmcraft.outputs.charms }}
-      - id: charm-name
-        run: |
-          echo charm-name=`yq -r .name charmcraft.yaml` >> $GITHUB_OUTPUT
-      - run: |
-          sudo apt update && sudo apt install python3-yaml -y
-      - name: update upstream-source
-        shell: python
-        run: |
-          import yaml
-          
-          charmcraft_yaml = yaml.safe_load(open("charmcraft.yaml"))
-          resources = charmcraft_yaml["resources"]
-          resources[list(resources)[0]]["upstream-source"] = "localhost:5000/rock:latest"
-          yaml.dump(charmcraft_yaml, open("charmcraft.yaml", "w"), sort_keys=False)
-      - run: |
-          echo upload charm ${{ steps.charm-name.outputs.charm-name }}
-      - run: |
-          cat charmcraft.yaml
-      - if: github.event_name == 'push'
-        name: publish charm
-        uses: canonical/charming-actions/upload-charm@2.7.0
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          built-charm-path: ${{ steps.charmcraft.outputs.charms }}
-          tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
+    - uses: actions/checkout@v6.0.2
+    - name: Remove Android SDK
+      run: sudo rm -rf /usr/local/lib/android
+    - name: change directory
+      run: |
+        TEMP_DIR=$(mktemp -d)
+        cp -rp ./${{ matrix.charm-dir }}/. $TEMP_DIR
+        rm -rf .* * || :
+        cp -rp $TEMP_DIR/. .
+        rm -rf $TEMP_DIR
+    - name: setup lxd
+      uses: canonical/setup-lxd@v1
+    - name: find rock
+      id: rock-dir
+      run: |
+        echo rock-dir=`dirname *rock/rockcraft.yaml` >> $GITHUB_OUTPUT
+    - name: build rock
+      id: rockcraft
+      run: |
+        sudo snap install --channel latest/stable --classic rockcraft
+        cd ${{ steps.rock-dir.outputs.rock-dir }}
+        rockcraft pack --verbosity trace
+        echo rock=`ls *.rock` >> $GITHUB_OUTPUT
+    - run: |
+        echo rockcraft pack:
+        echo ${{ steps.rockcraft.outputs.rock }}
+    - name: upload rock
+      run: |
+        cd ${{ steps.rock-dir.outputs.rock-dir }}
+        docker run -d -p 5000:5000 --name registry registry:latest
+        rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:${{ steps.rockcraft.outputs.rock }} docker://localhost:5000/rock:latest
+    - name: build charm
+      id: charmcraft
+      run: |
+        sudo snap install --channel latest/stable --classic charmcraft
+        charmcraft pack --verbosity trace
+        echo charms=`ls *.charm` >> $GITHUB_OUTPUT
+    - run: |
+        echo charmcraft pack:
+        echo ${{ steps.charmcraft.outputs.charms }}
+    - id: charm-name
+      run: |
+        echo charm-name=`yq -r .name charmcraft.yaml` >> $GITHUB_OUTPUT
+    - run: |
+        sudo apt update && sudo apt install python3-yaml -y
+    - name: update upstream-source
+      shell: python
+      run: |
+        import yaml
+
+        charmcraft_yaml = yaml.safe_load(open("charmcraft.yaml"))
+        resources = charmcraft_yaml["resources"]
+        resources[list(resources)[0]]["upstream-source"] = "localhost:5000/rock:latest"
+        yaml.dump(charmcraft_yaml, open("charmcraft.yaml", "w"), sort_keys=False)
+    - run: |
+        echo upload charm ${{ steps.charm-name.outputs.charm-name }}
+    - run: |
+        cat charmcraft.yaml
+    - if: github.event_name == 'push'
+      name: publish charm
+      uses: canonical/charming-actions/upload-charm@2.7.0
+      with:
+        credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        built-charm-path: ${{ steps.charmcraft.outputs.charms }}
+        tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
   publish-charm-libs:
     name: Release charm libs
     runs-on: ubuntu-24.04
-    needs: [ publish-charm ]
+    needs: [publish-charm]
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: canonical/charming-actions/release-libraries@2.7.0
-        name: Release libs
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v6.0.2
+    - uses: canonical/charming-actions/release-libraries@2.7.0
+      name: Release libs
+      with:
+        credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.